### PR TITLE
Customize the command usage.

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,14 @@ const (
 )
 
 func main() {
-	outputToCSV := flag.Bool("csv", false, "Output a CSV file with the results.")
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [--csv] username apikey\n\n", os.Args[0])
+
+		flag.CommandLine.PrintDefaults()
+	}
+
+	outputToCSV := flag.Bool("csv", false,
+		"Output a CSV file to 'cs-reboot-info-output.csv' in the current directory.")
 	flag.Parse()
 
 	if flag.NArg() != 2 {


### PR DESCRIPTION
Update the usage that's shown with `cs-reboot-info --help` to include the username and API key.

```
ashl6947@MMN1F3FD58 ~/code/cs-reboot-info (update-usage *) $ cs-reboot-info --help
Usage: cs-reboot-info [--csv] username apikey

  -csv=false: Output a CSV file to 'cs-reboot-info-output.csv' in the current directory.
```