### PR TITLE
Find and replace on the README links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # cs-reboot-info
 
-This is a Rackspace tool to identify Cloud Servers that have a scheduled automated reboot window. Cloud Servers may have a scheduled reboot in the case of routine or critical system maintenance. 
+This is a Rackspace tool to identify Cloud Servers that have a scheduled automated reboot window. Cloud Servers may have a scheduled reboot in the case of routine or critical system maintenance.
 
-The tool source is OS independent (written in Go) and binaries are available for Windows, Mac OS X, and Linux. 
+The tool source is OS independent (written in Go) and binaries are available for Windows, Mac OS X, and Linux.
 
 # How it works
 
-*cs-reboot-info* queries the Rackspace Cloud US and UK cloud infrastructures (both First and Next Generation). It identifies any Cloud Servers with a metadata key named *"rax:reboot_window"*. This key carries a value that shows the start and end times of the scheduled reboot window for the Cloud Server. 
+*cs-reboot-info* queries the Rackspace Cloud US and UK cloud infrastructures (both First and Next Generation). It identifies any Cloud Servers with a metadata key named *"rax:reboot_window"*. This key carries a value that shows the start and end times of the scheduled reboot window for the Cloud Server.
 
 The format of the metadata key is:
 
@@ -16,33 +16,33 @@ The format of the metadata key is:
 | rax:reboot_window | 2014-01-28T00:00:00Z;2014-01-28T03:00:00Z |
 ```
 
-The value is a semi-colon separated time range, in UTC format. 
+The value is a semi-colon separated time range, in UTC format.
 
-The tool outputs a list of Cloud Servers that have scheduled reboot windows in a tabular format. Results can optionally be saved to a CSV file. 
+The tool outputs a list of Cloud Servers that have scheduled reboot windows in a tabular format. Results can optionally be saved to a CSV file.
 
-**Note:** Only Cloud Servers with a scheduled reboot window will be listed. If a Cloud Server is not listed, no automated reboots are scheduled for it. 
+**Note:** Only Cloud Servers with a scheduled reboot window will be listed. If a Cloud Server is not listed, no automated reboots are scheduled for it.
 
 
 ## Installation - Binaries
 
 | Plaform        | Download links |
 | -------------- | -------------- |
-| Windows 386    | [`cs-reboot-info_windows_386.exe`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_windows_386.exe) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_windows_386.exe.sha1)) |
-| Windows AMD64  | [`cs-reboot-info_windows_amd64.exe`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_windows_amd64.exe) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_windows_amd64.exe.sha1)) |
-| Mac OS X 386   | [`cs-reboot-info_darwin_386`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_darwin_386) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_darwin_386.sha1)) |
-| Mac OS X AMD64 | [`cs-reboot-info_darwin_amd64`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_darwin_amd64) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_darwin_amd64.sha1)) |
-| FreeBSD 386    | [`cs-reboot-info_freebsd_386`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_freebsd_386) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_freebsd_386.sha1)) |
-| FreeBSD AMD64  | [`cs-reboot-info_freebsd_amd64`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_freebsd_amd64) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_freebsd_amd64.sha1)) |
-| FreeBSD ARM    | [`cs-reboot-info_freebsd_arm`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_freebsd_arm) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_freebsd_arm.sha1)) |
-| Linux 386      | [`cs-reboot-info_linux_amd64`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_linux_386) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_linux_386.sha1)) |
-| Linux AMD64    | [`cs-reboot-info_linux_amd64`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_linux_amd64) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_linux_amd64.sha1)) |
-| Linux ARM      | [`cs-reboot-info_linux_arm`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_linux_arm) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_linux_arm.sha1)) |
-| NetBSD 386     | [`cs-reboot-info_netbsd_386`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_netbsd_386) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_netbsd_386.sha1)) |
-| NetBSD AMD64   | [`cs-reboot-info_netbsd_amd64`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_netbsd_amd64) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_netbsd_amd64.sha1)) |
-| NetBSD ARM     | [`cs-reboot-info_netbsd_arm`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_netbsd_arm) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_netbsd_arm.sha1)) |
-| OpenBSD 386    | [`cs-reboot-info_openbsd_386`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_openbsd_386) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_openbsd_386.sha1)) |
-| OpenBSD AMD64  | [`cs-reboot-info_openbsd_amd64`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_openbsd_amd64) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_openbsd_amd64.sha1)) |
-| Plan 9 386     | [`cs-reboot-info_plan9_386`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_plan9_386) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/cs-reboot-info_plan9_386.sha1)) |
+| Windows 386    | [`cs-reboot-info_windows_386.exe`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_windows_386.exe) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_windows_386.exe.sha1)) |
+| Windows AMD64  | [`cs-reboot-info_windows_amd64.exe`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_windows_amd64.exe) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_windows_amd64.exe.sha1)) |
+| Mac OS X 386   | [`cs-reboot-info_darwin_386`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_darwin_386) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_darwin_386.sha1)) |
+| Mac OS X AMD64 | [`cs-reboot-info_darwin_amd64`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_darwin_amd64) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_darwin_amd64.sha1)) |
+| FreeBSD 386    | [`cs-reboot-info_freebsd_386`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_freebsd_386) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_freebsd_386.sha1)) |
+| FreeBSD AMD64  | [`cs-reboot-info_freebsd_amd64`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_freebsd_amd64) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_freebsd_amd64.sha1)) |
+| FreeBSD ARM    | [`cs-reboot-info_freebsd_arm`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_freebsd_arm) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_freebsd_arm.sha1)) |
+| Linux 386      | [`cs-reboot-info_linux_amd64`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_linux_386) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_linux_386.sha1)) |
+| Linux AMD64    | [`cs-reboot-info_linux_amd64`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_linux_amd64) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_linux_amd64.sha1)) |
+| Linux ARM      | [`cs-reboot-info_linux_arm`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_linux_arm) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_linux_arm.sha1)) |
+| NetBSD 386     | [`cs-reboot-info_netbsd_386`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_netbsd_386) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_netbsd_386.sha1)) |
+| NetBSD AMD64   | [`cs-reboot-info_netbsd_amd64`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_netbsd_amd64) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_netbsd_amd64.sha1)) |
+| NetBSD ARM     | [`cs-reboot-info_netbsd_arm`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_netbsd_arm) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_netbsd_arm.sha1)) |
+| OpenBSD 386    | [`cs-reboot-info_openbsd_386`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_openbsd_386) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_openbsd_386.sha1)) |
+| OpenBSD AMD64  | [`cs-reboot-info_openbsd_amd64`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_openbsd_amd64) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_openbsd_amd64.sha1)) |
+| Plan 9 386     | [`cs-reboot-info_plan9_386`](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_plan9_386) ([SHA1](https://a4fae0f0d6cf4cc92acd-d6ce857812540f8fb39144d83ca6538f.ssl.cf5.rackcdn.com/08c510b/cs-reboot-info_plan9_386.sha1)) |
 
 After you download the binary, place it anywhere on your `${PATH}` (or `%PATH%`) and rename it to `cs-reboot-info`. On Mac or Linux, you'll also need to `chmod +x cs-reboot-info` to make it executable.
 
@@ -52,9 +52,9 @@ After you download the binary, place it anywhere on your `${PATH}` (or `%PATH%`)
 ```bash
 cs-reboot-info [--csv] username apikey
 ```
-*Username* and *apikey* are required arguments, and are the same credentials you normally use with the Rackspace Cloud API (or to log in the Cloud Control Panel). 
+*Username* and *apikey* are required arguments, and are the same credentials you normally use with the Rackspace Cloud API (or to log in the Cloud Control Panel).
 
-*--csv*: Optional, used to specify that you also want the results stored in a CSV file titled **cs-reboot-info.csv** in the same directory as the tool. 
+*--csv*: Optional, used to specify that you also want the results stored in a CSV file titled **cs-reboot-info.csv** in the same directory as the tool.
 
 
 ### Sample output: Table (default)
@@ -92,6 +92,3 @@ go get .
 # Build and install the binary to ${GOPATH}/bin
 go install .
 ```
-
-
-


### PR DESCRIPTION
Point the download links to a folder named after `git rev-parse --short HEAD` of the commit that was built, so we don't need to wait for CDN expiration to push new versions.

Naturally this means we'll need to update the README every time we push a new release.