### PR TITLE
Change output logic to always tabular

### DIFF
--- a/main.go
+++ b/main.go
@@ -131,11 +131,10 @@ func main() {
 	}
 
 	if len(entries) > 0 {
+		fmt.Printf("There are %d Cloud Servers with an automated reboot scheduled.", len(entries))
+		outputTabular(entries)
 		if *outputToCSV {
 			outputCSV(entries)
-		} else {
-			fmt.Printf("The following %d Cloud Servers have an automated reboot scheduled:", len(entries))
-			outputTabular(entries)
 		}
 	}
 }


### PR DESCRIPTION
Changed to always output the count, and the tabular version, and then optionally the CSV at the end. Should also help catch more errors.