### PR TITLE
Always output version, msg on no srvrs

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,9 +150,7 @@ func main() {
 			outputCSV(entries)
 		}
 	} else {
-		fmt.Printf("cs-reboot-info version %s\n\n", appVer)
 		fmt.Printf("You have no Cloud Servers with an automated reboot scheduled.\n")
-		os.Exit(0)
 }
 
 // Regions acquires the service catalog and returns a slice of every region that contains a next-gen

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 const (
 	metadataKey     = "rax:reboot_window"
 	metadataTimeFmt = "2006-01-02T15:04:05Z"
-	appVer          = "1.1"
+	appVer          = "1.2"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 	provider.UserAgent.Prepend(fmt.Sprintf("cs-reboot-info/%s", appVer))
 
 	regions, fg := Regions(provider, opts)
-
+	fmt.Printf("cs-reboot-info version %s\n\n", appVer)
 	fmt.Printf("Regions with a Cloud Servers endpoint: %s\n", strings.Join(regions, ", "))
 	if fg {
 		fmt.Println("Found both First and Next Generation endpoints.")
@@ -149,7 +149,10 @@ func main() {
 		if *outputToCSV {
 			outputCSV(entries)
 		}
-	}
+	} else {
+		fmt.Printf("cs-reboot-info version %s\n\n", appVer)
+		fmt.Printf("You have no Cloud Servers with an automated reboot scheduled.\n")
+		os.Exit(0)
 }
 
 // Regions acquires the service catalog and returns a slice of every region that contains a next-gen


### PR DESCRIPTION
Always output the tool version, and added a message to confirm when there are no servers with a reboot found. (Versus silent exit).